### PR TITLE
Secret.data can be sent to Kubernetes

### DIFF
--- a/lib/Kubernetes/Model/V1/Secret.hs
+++ b/lib/Kubernetes/Model/V1/Secret.hs
@@ -41,7 +41,11 @@ data Secret = Secret
 
 makeLenses ''Secret
 
-$(deriveJSON defaultOptions{fieldLabelModifier = (\n -> if n == "_type_" then "type" else P.drop 1 n)} ''Secret)
+$(deriveJSON defaultOptions{fieldLabelModifier =
+  (\n -> case n of
+    "_type_" -> "type"
+    "_data_" -> "data"
+    _ -> P.drop 1 n)} ''Secret)
 
 instance Arbitrary Secret where
     arbitrary = Secret <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary


### PR DESCRIPTION
Without the change the fieldname `_data_` will be translated to `data_` which
is not a valid field in the Kubernetes Secret resource.
Probably this should be fixed in the generator as well.